### PR TITLE
add external name kind to helm

### DIFF
--- a/stable/application-helm/Chart.yaml
+++ b/stable/application-helm/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: application-helm
 description: A generic helm chart for all sort of applications
-version: 0.0.13
+version: 0.0.14

--- a/stable/application-helm/templates/external-service.yaml
+++ b/stable/application-helm/templates/external-service.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.external-service }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "external-service.name" . }}
+  labels:
+    {{ include "application.labels" . | indent 4 }}
+    {{ include "application.labels.chart" . | nindent 4 }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.external-service.ip-address }}
+{{- end }}

--- a/stable/application-helm/values.yaml
+++ b/stable/application-helm/values.yaml
@@ -197,6 +197,11 @@ service:
       protocol: TCP
       targetPort: 8080
 
+
+  external-service:
+    # - name: my-database-name
+    # - ip-address: 16.0.0.2
+
 # Ingress object for exposing services
 ingress:
   enabled: false


### PR DESCRIPTION
 An ExternalName service is a way to provide an alias for an external resource outside the Kubernetes cluster. Instead of mapping to a selector and forwarding traffic to a set of pods, an ExternalName service acts as a DNS CNAME record.

When you define an ExternalName service, Kubernetes does not create any endpoints or proxies for the service. Instead, it simply returns a DNS record with the specified external name value. When the Kubernetes cluster attempts to reach the service by its name, it resolves the name to the associated external name value, typically a DNS name or IP address.

This type of service is useful when you want to map a Kubernetes service to an external resource, such as an external database, external load balancer, or any other service residing outside the cluster. It allows you to reference the external resource using a service name within the cluster, abstracting the underlying network details.

Note that an ExternalName service only supports the TCP and UDP protocols and cannot provide load balancing or scaling features like other service types such as ClusterIP or NodePort