### PR TITLE
Adding ability to add a scheduled CronTask as part of the generic chart:

### DIFF
--- a/stable/application-helm/templates/crontask.yaml
+++ b/stable/application-helm/templates/crontask.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.cronTasks }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+{{ include "application.labels" . | indent 4 }}
+{{ include "application.labels.chart" . | indent 4 }}
+{{- if .Values.deployment.additionalLabels }}
+{{ toYaml .Values.deployment.additionalLabels | indent 4 }}
+{{- end }}
+{{- if .Values.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.annotations | indent 4 }}
+{{- end }}
+  name: {{ template "application.name" . }}
+spec:
+  schedule: {{ .schedule }}
+  jobTemplate:
+    metadata:
+      name: {{ template "application.name" . }}
+    spec:
+      template:
+        metadata:
+          name: {{ template "application.name" . }}
+        spec:
+          containers:
+          - name: cron-job
+            image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+            imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+            command: ["/bin/bash"]
+            args: ["-c", "{{ .command }}"]
+          restartPolicy: OnFailure
+{{- end }}

--- a/stable/application-helm/values.yaml
+++ b/stable/application-helm/values.yaml
@@ -406,3 +406,9 @@ autoscaling:
       name: memory
       targetAverageUtilization: 60
 
+# cronTasks {name, command, schedule}.
+# CronJobs to run either an arbitrary command.
+cronTasks:
+  - name: run-some-script
+    command: "script/some_script"
+    schedule: "1 * * * *"


### PR DESCRIPTION
To add a new cron as part of the deployment:
  the values in app deployment must contain example:

```
cronTasks:
  - name: run-some-script
    command: "script/some_script"
    schedule: "1 * * * *"
```
**For now the command executes bash script.**


_**Tested using helm template:**_

**Output with cron enabled:**
```
# Source: application-helm/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    app: application-helm
    appVersion: "v1.0.0"
    group: application-helm
    chart: "application-helm-0.0.19"
    release: "application-setup"
    heritage: "Helm"
  name: application-helm
---
# Source: application-helm/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: application-helm
    appVersion: "v1.0.0"
    group: application-helm
    chart: "application-helm-0.0.19"
    release: "application-setup"
    heritage: "Helm"
  name: application-helm
spec:
  selector:
    app: application-helm
  ports:
    - name: http
      port: 8080
      protocol: TCP
      targetPort: 8080
---
# Source: application-helm/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: application-helm
    appVersion: "v1.0.0"
    group: application-helm
    chart: "application-helm-0.0.19"
    release: "application-setup"
    heritage: "Helm"
  name: application-helm
spec:
  replicas: 1
  revisionHistoryLimit: 4
  selector:
    matchLabels:
      app: application-helm
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: application-helm
    spec:      
      imagePullSecrets:
      - name: docker
      containers:
      - name: application-helm
        image: "repository/image-name:v1.0.0"
        imagePullPolicy: IfNotPresent
        securityContext:      
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - all
          readOnlyRootFilesystem: true
        env:
          - name: ENVIRONMENT
            value: dev
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /actuator/health/liveness
            port: 8080
          initialDelaySeconds: 30
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        readinessProbe:
          failureThreshold: 3
          httpGet:
            path: /actuator/health/readiness
            port: 8080
          initialDelaySeconds: 10
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        resources:
          limits:
            memory: 512Mi
          requests:
            cpu: 0.2
            memory: 128Mi
      securityContext:      
        fsGroup: 2000
        runAsGroup: 3000
        runAsNonRoot: true
        runAsUser: 1001
      serviceAccountName: application-helm
---
# Source: application-helm/templates/crontask.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  labels:
    app: application-helm
    appVersion: "v1.0.0"
    group: application-helm
    chart: "application-helm-0.0.19"
    release: "application-setup"
    heritage: "Helm"
  name: application-helm
spec:
  schedule: 
  jobTemplate:
    metadata:
      name: application-helm
    spec:
      template:
        metadata:
          name: application-helm
        spec:
          containers:
          - name: cron-job
            image: "repository/image-name:v1.0.0"
            imagePullPolicy: IfNotPresent
            command: ["/bin/bash"]
            args: ["-c", ""]
          restartPolicy: OnFailure
---
# Source: application-helm/templates/serviceMonitor.yaml
apiVersion: "monitoring.coreos.com/v1"
kind: ServiceMonitor
metadata:
  labels:
    app: application-helm
    appVersion: "v1.0.0"
    group: application-helm
    chart: "application-helm-0.0.19"
    release: "application-setup"
    heritage: "Helm"
  name: application-helm
spec:
  selector:
    matchLabels:
      app: application-helm
  namespaceSelector:
    matchNames:
    - applications
  endpoints:
    - interval: 10s
      path: /actuator/prometheus
      port: http
---
# Source: application-helm/templates/tests/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "application-helm-test-connection"
  labels:
    app: application-helm
    appVersion: "v1.0.0"
    group: application-helm
    chart: "application-helm-0.0.19"
    release: "application-setup"
    heritage: "Helm"
  annotations:
    "helm.sh/hook": test-success
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['application-helm:8080']
  restartPolicy: Never

```